### PR TITLE
Specify the URL while calling AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ S3 is storage for the Internet. The [Apex client](https://github.com/bigassforce
     String name = 'thebucket';
     s3.createBucket(name);
 
+    If redirect from AWS, it is possibile to specify the base AWS url:
+    AwsSdk.S3 s3 = connector.s3(region, 's3.us-east-1.amazonaws.com');
+
+
 ###### Adding an object to a bucket:
 
     AwsSdk.S3.Bucket bucket = connector.s3(region).bucket('thebucket');

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Amazon Web Services SDK for Salesforce Apex
 
+<a href="https://githubsfdeploy.herokuapp.com">
+  <img alt="Deploy to Salesforce" src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
+</a>
+
 The AWS SDK for Salesforce makes it easy for developers to access Amazon Web Services in their Apex code, and build robust applications and software using services like Amazon S3, Amazon EC2, etc. You can get started in minutes by [installing the package](installing the package).
 
 #### Amazon Simple Storage Service (S3) SDK

--- a/src/classes/Connector.cls
+++ b/src/classes/Connector.cls
@@ -5,8 +5,8 @@
  * Example usage:
  * String key = 'XXXXXXXXXXXXXXXXXXXX';
  * String secret = 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY';
- * AwsSdk.S3 s3 = new AwsSdk.Connector(key, secret).s3('us-east-1');
- * AwsSdk.Ec2 ec2 = new AwsSdk.Connector(key, secret).ec2('us-east-1');
+ * AwsSdk.S3 s3 = new AwsSdk.Connector(key, secret).s3('us-east-1', 'https://s3.us-east-1.amazonaws.com');
+ * AwsSdk.Ec2 ec2 = new AwsSdk.Connector(key, secret).ec2('us-east-1', 'https://s3.us-east-1.amazonaws.com');
  */
 public class Connector {
 
@@ -14,6 +14,7 @@ public class Connector {
     String secretKey;
     public String service;
     public String region;
+    public String baseURL;
     @TestVisible Datetime now = Datetime.now();
 
     public Connector(String accessKeyId, String secretKey) {
@@ -21,12 +22,19 @@ public class Connector {
         this.secretKey = secretKey;
     }
 
+    public S3 s3(String region, String baseURL) {
+        return new S3(this, region, baseURL);
+    }    
+
     public S3 s3(String region) {
-        return new s3(this, region);
+        return new S3(this, region, null);
     }
 
+    public Ec2 ec2(String region, String baseURL) {
+        return new ec2(this, region, baseURL);
+    }    
     public Ec2 ec2(String region) {
-        return new ec2(this, region);
+        return new ec2(this, region, null);
     }
 
     /**
@@ -78,6 +86,8 @@ public class Connector {
             + '\n' + signedHeadersFor(headers)
             + '\n' + (presign ? 'UNSIGNED-PAYLOAD' : hexEncodedHashFor(payload))
         ;
+        system.debug('@@parameters: '+parameters);
+        system.debug('@@canonicalRequest: '+canonicalRequest);
 
         //Task 2: Create a String to Sign for Signature Version 4
         //https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html

--- a/src/classes/Ec2.cls
+++ b/src/classes/Ec2.cls
@@ -10,6 +10,7 @@
  *
  * String region = 'eu-east-1';
  * AwsSdk.Ec2 ec2 = connector.ec2(region);
+* String baseURL = s3.us-east-1.amazonaws.com';
  * AwsSdk.Ec2.DescribeInstancesResponse response = ec2.describeInstances(null);
  */
 public class Ec2 {
@@ -21,6 +22,7 @@ public class Ec2 {
         this.connector = connector;
         this.connector.region = region;
         this.connector.service = 'ec2';
+        this.connector.baseURL = baseURL;
     }
 
     /**

--- a/src/classes/S3.cls
+++ b/src/classes/S3.cls
@@ -55,7 +55,7 @@ public class S3 {
         Bucket(Connector connector, String bucket) {
             this.connector = connector;
             this.Name = bucket;
-            this.endpointURL = (connector.baseURL != null) ? 'http://'+Name+'.'+connector.baseURL : 'http://s3.amazonaws.com/';
+            this.endpointURL = (connector.baseURL != null) ? 'http://'+Name+'.'+connector.baseURL+'/' : 'http://s3.amazonaws.com/';
         }
 
         /**

--- a/src/classes/S3.cls
+++ b/src/classes/S3.cls
@@ -9,7 +9,8 @@
  * AwsSdk.Connector connector = new AwsSdk.Connector(accessKey, secretKey);
  *
  * String region = 'us-east-1';
- * AwsApi.S3 s3 = connector.s3(region);
+ * String baseURL = 's3.us-east-1.amazonaws.com';
+ * AwsApi.S3 s3 = connector.s3(region, baseURL);
  * List<AwsApi.S3.Content> contents = s3.bucket('bucketname').listContents(null);
  */
 public class S3 {
@@ -17,15 +18,16 @@ public class S3 {
     public class ClientException extends Exception {}
 
     Connector connector;
-    public S3(Connector connector, String region) {
+    public S3(Connector connector, String region, String baseURL) {
         this.connector = connector;
         this.connector.region = region;
         this.connector.service = 's3';
+        this.connector.baseURL = baseURL;
     }
 
     /**
      * Example usage:
-     * new AwsSdk.Connector('access', 'secret').s3('us-east-1').bucket('bucketname');
+     * new AwsSdk.Connector('access', 'secret').s3('us-east-1', 's3.us-east-1.amazonaws.com').bucket('bucketname');
      */
     public Bucket bucket(String name) {
         return new Bucket(this.connector, name);
@@ -47,15 +49,18 @@ public class S3 {
          */
         public Datetime CreationDate;
 
+        private String endpointURL;
+
         Connector connector;
         Bucket(Connector connector, String bucket) {
             this.connector = connector;
             this.Name = bucket;
+            this.endpointURL = (connector.baseURL != null) ? 'https://'+Name+'.'+connector.baseURL : 'https://s3.amazonaws.com';
         }
 
         /**
          * Example usage:
-         * new AwsSdk.Connector('access', 'secret').s3('us-east-1').bucket('bucketname').content('key');
+         * new AwsSdk.Connector('access', 'secret').s3('us-east-1', 's3.us-east-1.amazonaws.com').bucket('bucketname').content('key');
          */
         public Content content(String key) {
             return new Content(this, key);
@@ -66,11 +71,12 @@ public class S3 {
          * https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
          */
         public List<Content> listContents(ListContentsRequest listContentsRequest) {
-            PageReference pr = new PageReference('https://s3.amazonaws.com/' + this.Name);
+            PageReference pr = new PageReference(endpointURL);
             Map<String,String> parameters = new RequestFormatter(listContentsRequest).getMap();
             pr.getParameters().putAll(parameters);
 
             Url endpoint = new Url(pr.getUrl());
+            system.debug('@@endpoint '+endpoint);
             HttpRequest request = this.connector.signedRequest('GET', endpoint, null, null, null);
             HttpResponse response = new Http().send(request);
             if (response.getStatusCode() != 200) throw new ClientException(response.getBody());
@@ -96,7 +102,7 @@ public class S3 {
          */
         public HttpResponse deleteContent(String key) {
             if (key.startsWith('/')) throw new ClientException('Keys should not lead with slash');
-            Url endpoint = new Url('https://s3.amazonaws.com/' + this.Name + '/' + key);
+            Url endpoint = new Url(endpointURL + '/' + key);
             HttpRequest request = this.connector.signedRequest('DELETE', endpoint, null, null, null);
             HttpResponse response = new Http().send(request);
             if (response.getStatusCode() != 204) throw new ClientException(response.getBody());
@@ -110,7 +116,7 @@ public class S3 {
          */
         public HttpResponse createContent(String key, Map<String,String> headers, Blob payload) {
             if (key.startsWith('/')) throw new ClientException('Keys should not lead with slash');
-            Url endpoint = new Url('https://s3.amazonaws.com/' + this.Name + '/' + key);
+            Url endpoint = new Url(endpointURL + '/' + key);
             HttpRequest request = this.connector.signedRequest('PUT', endpoint, headers, payload, null);
             HttpResponse response = new Http().send(request);
             if (response.getStatusCode() != 200) throw new ClientException(response.getBody());
@@ -166,7 +172,7 @@ public class S3 {
          */
         public HttpRequest presign() {
             String method = 'GET';
-            Url endpoint = new Url('https://s3.amazonaws.com/' + this.bucket.Name + '/' + this.Key);
+            Url endpoint = new Url(this.bucket.endpointURL + '/' + this.Key);
             Map<String,String> headers = new Map<String,String>();
             Blob payload = null;
             Boolean presign = true;

--- a/src/classes/S3.cls
+++ b/src/classes/S3.cls
@@ -55,7 +55,7 @@ public class S3 {
         Bucket(Connector connector, String bucket) {
             this.connector = connector;
             this.Name = bucket;
-            this.endpointURL = (connector.baseURL != null) ? 'http://'+Name+'.'+connector.baseURL+'/' : 'http://s3.amazonaws.com/';
+            this.endpointURL = (connector.baseURL != null) ? 'https://'+Name+'.'+connector.baseURL+'/' : 'https://s3.amazonaws.com/';
         }
 
         /**

--- a/src/classes/S3.cls
+++ b/src/classes/S3.cls
@@ -55,7 +55,7 @@ public class S3 {
         Bucket(Connector connector, String bucket) {
             this.connector = connector;
             this.Name = bucket;
-            this.endpointURL = (connector.baseURL != null) ? 'https://'+Name+'.'+connector.baseURL : 'https://s3.amazonaws.com';
+            this.endpointURL = (connector.baseURL != null) ? 'http://'+Name+'.'+connector.baseURL : 'http://s3.amazonaws.com';
         }
 
         /**

--- a/src/classes/S3.cls
+++ b/src/classes/S3.cls
@@ -55,7 +55,7 @@ public class S3 {
         Bucket(Connector connector, String bucket) {
             this.connector = connector;
             this.Name = bucket;
-            this.endpointURL = (connector.baseURL != null) ? 'http://'+Name+'.'+connector.baseURL : 'http://s3.amazonaws.com';
+            this.endpointURL = (connector.baseURL != null) ? 'http://'+Name+'.'+connector.baseURL : 'http://s3.amazonaws.com/';
         }
 
         /**

--- a/src/classes/S3Test.cls
+++ b/src/classes/S3Test.cls
@@ -232,7 +232,7 @@
 
         //assert
         System.assertEquals('https', endpoint.getProtocol(), 'wrong protocol');
-        System.assertEquals('s3.us-east-1.amazonaws.com', endpoint.getHost(), 'wrong host');
+        System.assertEquals('bucketname.s3.us-east-1.amazonaws.com', endpoint.getHost(), 'wrong host');
         System.assertEquals('/bucketname/path/to/file.ext', endpoint.getPath(), 'wrong path');
 
         System.assertEquals('AWS4-HMAC-SHA256', parameters.get('X-Amz-Algorithm'), 'wrong algorithm');

--- a/src/classes/S3Test.cls
+++ b/src/classes/S3Test.cls
@@ -233,13 +233,13 @@
         //assert
         System.assertEquals('https', endpoint.getProtocol(), 'wrong protocol');
         System.assertEquals('bucketname.s3.us-east-1.amazonaws.com', endpoint.getHost(), 'wrong host');
-        System.assertEquals('/bucketname/path/to/file.ext', endpoint.getPath(), 'wrong path');
+        System.assertEquals('/path/to/file.ext', endpoint.getPath(), 'wrong path');
 
         System.assertEquals('AWS4-HMAC-SHA256', parameters.get('X-Amz-Algorithm'), 'wrong algorithm');
         System.assertEquals('access/20150830/us-east-1/s3/aws4_request', parameters.get('X-Amz-Credential'), 'wrong credential');
         System.assertEquals('20150830T123600Z', parameters.get('X-Amz-Date'), 'wrong date');
         System.assertEquals('86400', parameters.get('X-Amz-Expires'), 'wrong expires');
-        System.assertEquals('888d7756ffdb691bb7f12cf040455a5ba89871193a8fa666177f4cf3565ad9c5', parameters.get('X-Amz-Signature'), 'wrong signature');
+        System.assertEquals('d1f8048e80dc8fbb4343bd716e1db263f8515737f33cacb28c79fb64486f7e8e', parameters.get('X-Amz-Signature'), 'wrong signature');
         System.assertEquals('host', parameters.get('X-Amz-SignedHeaders'), 'wrong signature');
     }
 

--- a/src/classes/S3Test.cls
+++ b/src/classes/S3Test.cls
@@ -59,7 +59,7 @@
         Test.setMock(HttpCalloutMock.class, new MockListBucketsResponder());
 
         //act
-        S3 s3 = new Connector('access', 'secret').s3('us-east-1');
+        S3 s3 = new Connector('access', 'secret').s3('us-east-1', 's3.us-east-1.amazonaws.com');
         List<S3.Bucket> buckets = s3.listBuckets();
 
         //assert
@@ -81,7 +81,7 @@
         Test.setMock(HttpCalloutMock.class, new MockCreateBucketResponder());
 
         //act
-        S3 s3 = new Connector('access', 'secret').s3('us-east-1');
+        S3 s3 = new Connector('access', 'secret').s3('us-east-1', 's3.us-east-1.amazonaws.com');
         HttpResponse response = s3.createBucket('bucketname');
 
         //assert
@@ -101,7 +101,7 @@
         Test.setMock(HttpCalloutMock.class, new MockDeleteBucketResponder());
 
         //act
-        S3 s3 = new Connector('access', 'secret').s3('us-east-1');
+        S3 s3 = new Connector('access', 'secret').s3('us-east-1', 's3.us-east-1.amazonaws.com');
         HttpResponse response = s3.deleteBucket('bucketname');
 
         //assert
@@ -155,7 +155,7 @@
         Test.setMock(HttpCalloutMock.class, new MockListContentsResponder());
 
         //act
-        S3 s3 = new Connector('access', 'secret').s3('us-east-1');
+        S3 s3 = new Connector('access', 'secret').s3('us-east-1', 's3.us-east-1.amazonaws.com');
         List<S3.Content> contents = s3.bucket('bucketname').listContents(null);
 
         //assert
@@ -191,7 +191,7 @@
         Test.setMock(HttpCalloutMock.class, new MockCreateContentResponder());
 
         //act
-        S3 s3 = new Connector('access', 'secret').s3('us-east-1');
+        S3 s3 = new Connector('access', 'secret').s3('us-east-1', 's3.us-east-1.amazonaws.com');
         HttpResponse response = s3.bucket('bucketname').createContent('directory/file.txt', null, null);
 
         //assert
@@ -211,7 +211,7 @@
         Test.setMock(HttpCalloutMock.class, new MockDeleteContentResponder());
 
         //act
-        S3 s3 = new Connector('access', 'secret').s3('us-east-1');
+        S3 s3 = new Connector('access', 'secret').s3('us-east-1', 's3.us-east-1.amazonaws.com');
         HttpResponse response = s3.bucket('bucketname').deleteContent('path/to/file.ext');
 
         //assert
@@ -224,7 +224,7 @@
         connector.now = Datetime.newInstanceGmt(2015, 08, 30, 12, 36, 00);
 
         //act
-        HttpRequest request = connector.s3('us-east-1').bucket('bucketname').content('path/to/file.ext').presign();
+        HttpRequest request = connector.s3('us-east-1', 's3.us-east-1.amazonaws.com').bucket('bucketname').content('path/to/file.ext').presign();
 
         //assemble
         Url endpoint = new Url(request.getEndpoint());
@@ -232,7 +232,7 @@
 
         //assert
         System.assertEquals('https', endpoint.getProtocol(), 'wrong protocol');
-        System.assertEquals('s3.amazonaws.com', endpoint.getHost(), 'wrong host');
+        System.assertEquals('s3.us-east-1.amazonaws.com', endpoint.getHost(), 'wrong host');
         System.assertEquals('/bucketname/path/to/file.ext', endpoint.getPath(), 'wrong path');
 
         System.assertEquals('AWS4-HMAC-SHA256', parameters.get('X-Amz-Algorithm'), 'wrong algorithm');


### PR DESCRIPTION
Hi,

thanks for sharing this repository on Github! The AWS toolkit is so old, it doesn't work anymore with v4 authentication.

Anyway, when I tried to connect to AWS, I've got a 'permanent redirect' status. So I slightly modified the classes to allow the user to write a base URL while instantiating the Connector. If not specified, the methods work as before.